### PR TITLE
Remove reduced model method from robot-handler

### DIFF
--- a/bindings/expose-robot-handler.cpp
+++ b/bindings/expose-robot-handler.cpp
@@ -21,12 +21,10 @@ namespace simple_mpc
     void exposeHandler()
     {
       bp::class_<RobotModelHandler>(
-        "RobotModelHandler",
-        bp::init<const pinocchio::Model &, const std::string &, const std::string &, const std::vector<std::string> &>(
-          bp::args("self", "model", "reference_configuration_name", "base_frame_name", "locked_joint_names")))
+        "RobotModelHandler", bp::init<const pinocchio::Model &, const std::string &, const std::string &>(
+                               bp::args("self", "model", "reference_configuration_name", "base_frame_name")))
         .def("addFoot", &RobotModelHandler::addFoot)
         .def("difference", &RobotModelHandler::difference)
-        .def("shapeState", &RobotModelHandler::shapeState)
         .def("getBaseFrameId", &RobotModelHandler::getBaseFrameId)
         .def("getReferenceState", &RobotModelHandler::getReferenceState)
         .def("getFootNb", &RobotModelHandler::getFootNb)
@@ -37,8 +35,7 @@ namespace simple_mpc
         .def("getFootId", &RobotModelHandler::getFootId)
         .def("getRefFootId", &RobotModelHandler::getRefFootId)
         .def("getMass", &RobotModelHandler::getMass)
-        .def("getModel", &RobotModelHandler::getModel, bp::return_internal_reference<>())
-        .def("getCompleteModel", &RobotModelHandler::getCompleteModel, bp::return_internal_reference<>());
+        .def("getModel", &RobotModelHandler::getModel, bp::return_internal_reference<>());
 
       ENABLE_SPECIFIC_MATRIX_TYPE(RobotDataHandler::CentroidalStateVector);
 

--- a/bindings/expose-robot-handler.cpp
+++ b/bindings/expose-robot-handler.cpp
@@ -31,7 +31,6 @@ namespace simple_mpc
         .def("getFeetIds", &RobotModelHandler::getFeetIds, bp::return_internal_reference<>())
         .def("getFootName", &RobotModelHandler::getFootName, bp::return_internal_reference<>())
         .def("getFeetNames", &RobotModelHandler::getFeetNames, bp::return_internal_reference<>())
-        .def("getControlledJointNames", &RobotModelHandler::getControlledJointNames)
         .def("getFootId", &RobotModelHandler::getFootId)
         .def("getRefFootId", &RobotModelHandler::getRefFootId)
         .def("getMass", &RobotModelHandler::getMass)

--- a/examples/go2_fulldynamics.py
+++ b/examples/go2_fulldynamics.py
@@ -14,7 +14,7 @@ base_joint_name ="root_joint"
 robot_wrapper = erd.load('go2')
 
 # Create Model and Data handler
-model_handler = RobotModelHandler(robot_wrapper.model, "standing", base_joint_name, [])
+model_handler = RobotModelHandler(robot_wrapper.model, "standing", base_joint_name)
 model_handler.addFoot("FL_foot", base_joint_name, pin.XYZQUATToSE3(np.array([ 0.17, 0.15, 0.0, 0,0,0,1])))
 model_handler.addFoot("FR_foot", base_joint_name, pin.XYZQUATToSE3(np.array([ 0.17,-0.15, 0.0, 0,0,0,1])))
 model_handler.addFoot("RL_foot", base_joint_name, pin.XYZQUATToSE3(np.array([-0.24, 0.15, 0.0, 0,0,0,1])))

--- a/examples/go2_kinodynamics.py
+++ b/examples/go2_kinodynamics.py
@@ -14,7 +14,7 @@ base_joint_name ="root_joint"
 robot_wrapper = erd.load('go2')
 
 # Create Model and Data handler
-model_handler = RobotModelHandler(robot_wrapper.model, "standing", base_joint_name, [])
+model_handler = RobotModelHandler(robot_wrapper.model, "standing", base_joint_name)
 model_handler.addFoot("FL_foot", base_joint_name, pin.XYZQUATToSE3(np.array([ 0.17, 0.15, 0.0, 0,0,0,1])))
 model_handler.addFoot("FR_foot", base_joint_name, pin.XYZQUATToSE3(np.array([ 0.17,-0.15, 0.0, 0,0,0,1])))
 model_handler.addFoot("RL_foot", base_joint_name, pin.XYZQUATToSE3(np.array([-0.24, 0.15, 0.0, 0,0,0,1])))
@@ -225,8 +225,8 @@ for t in range(300):
     com_measured.append(mpc.getDataHandler().getData().com[0].copy())
     L_measured.append(mpc.getDataHandler().getData().hg.angular.copy())
 
-    a0 = mpc.getStateDerivative(0)[nv:]
-    a1 = mpc.getStateDerivative(1)[nv:]
+    a0 = mpc.getStateDerivative(0)[nv:].copy()
+    a1 = mpc.getStateDerivative(1)[nv:].copy()
 
     a0[6:] = mpc.us[0][nk * force_size :]
     a1[6:] = mpc.us[1][nk * force_size :]

--- a/examples/talos_centroidal.py
+++ b/examples/talos_centroidal.py
@@ -3,29 +3,18 @@ import pinocchio as pin
 import example_robot_data as erd
 from bullet_robot import BulletRobot
 from simple_mpc import RobotModelHandler, RobotDataHandler, CentroidalOCP, MPC, IKIDSolver
+from utils import loadTalos
 import time
 
 # RobotWrapper
 URDF_SUBPATH = "/talos_data/robots/talos_reduced.urdf"
 base_joint_name ="root_joint"
-robot_wrapper = erd.load('talos')
-
 reference_configuration_name = "half_sitting"
-locked_joints = [
-    'arm_left_5_joint',
-    'arm_left_6_joint',
-    'arm_left_7_joint',
-    'gripper_left_joint',
-    'arm_right_5_joint',
-    'arm_right_6_joint',
-    'arm_right_7_joint',
-    'gripper_right_joint',
-    'head_1_joint',
-    'head_2_joint'
-]
+
+rmodelComplete, rmodel, qComplete, q0 = loadTalos()
 
 # Create Model and Data handler
-model_handler = RobotModelHandler(robot_wrapper.model, reference_configuration_name, base_joint_name, locked_joints)
+model_handler = RobotModelHandler(rmodel, reference_configuration_name, base_joint_name)
 model_handler.addFoot("left_sole_link",  base_joint_name, pin.XYZQUATToSE3(np.array([ 0.0, 0.1, 0.0, 0,0,0,1])))
 model_handler.addFoot("right_sole_link", base_joint_name, pin.XYZQUATToSE3(np.array([ 0.0,-0.1, 0.0, 0,0,0,1])))
 data_handler = RobotDataHandler(model_handler)

--- a/examples/talos_kinodynamics.py
+++ b/examples/talos_kinodynamics.py
@@ -3,29 +3,18 @@ import example_robot_data as erd
 import pinocchio as pin
 from bullet_robot import BulletRobot
 import time
+from utils import loadTalos
 from simple_mpc import RobotModelHandler, RobotDataHandler, KinodynamicsOCP, MPC, IDSolver
 
 # RobotWrapper
 URDF_SUBPATH = "/talos_data/robots/talos_reduced.urdf"
 base_joint_name ="root_joint"
-robot_wrapper = erd.load('talos')
-
 reference_configuration_name = "half_sitting"
-locked_joints = [
-    'arm_left_5_joint',
-    'arm_left_6_joint',
-    'arm_left_7_joint',
-    'gripper_left_joint',
-    'arm_right_5_joint',
-    'arm_right_6_joint',
-    'arm_right_7_joint',
-    'gripper_right_joint',
-    'head_1_joint',
-    'head_2_joint'
-]
+
+rmodelComplete, rmodel, qComplete, q0 = loadTalos()
 
 # Create Model and Data handler
-model_handler = RobotModelHandler(robot_wrapper.model, reference_configuration_name, base_joint_name, locked_joints)
+model_handler = RobotModelHandler(rmodel, reference_configuration_name, base_joint_name)
 model_handler.addFoot("left_sole_link",  base_joint_name, pin.XYZQUATToSE3(np.array([ 0.0, 0.1, 0.0, 0,0,0,1])))
 model_handler.addFoot("right_sole_link", base_joint_name, pin.XYZQUATToSE3(np.array([ 0.0,-0.1, 0.0, 0,0,0,1])))
 data_handler = RobotDataHandler(model_handler)
@@ -211,8 +200,8 @@ for t in range(600):
     end = time.time()
     print("MPC iterate = " + str(end - start))
 
-    a0 = mpc.getStateDerivative(0)[nv:]
-    a1 = mpc.getStateDerivative(1)[nv:]
+    a0 = mpc.getStateDerivative(0)[nv:].copy()
+    a1 = mpc.getStateDerivative(1)[nv:].copy()
     a0[6:] = mpc.us[0][nk * force_size :]
     a1[6:] = mpc.us[1][nk * force_size :]
     forces0 = mpc.us[0][: nk * force_size]

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,9 +1,22 @@
 import numpy as np
+import pinocchio as pin
+import example_robot_data
 import os
 
 CURRENT_DIRECTORY = os.getcwd()
 DEFAULT_SAVE_DIR = CURRENT_DIRECTORY + '/tmp'
 
+def loadTalos():
+    robotComplete = example_robot_data.load("talos")
+    qComplete = robotComplete.model.referenceConfigurations["half_sitting"]
+
+    locked_joints = [20,21,22,23,28,29,30,31]
+    locked_joints += [32, 33]
+    robot = robotComplete.buildReducedRobot(locked_joints, qComplete)
+    rmodel: pin.Model = robot.model
+    q0 = rmodel.referenceConfigurations["half_sitting"]
+
+    return robotComplete.model, rmodel, qComplete, q0
 
 def save_trajectory(
     xs,

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -10,8 +10,13 @@ def loadTalos():
     robotComplete = example_robot_data.load("talos")
     qComplete = robotComplete.model.referenceConfigurations["half_sitting"]
 
-    locked_joints = [20,21,22,23,28,29,30,31]
-    locked_joints += [32, 33]
+    locked_joints_names = ["arm_left_5_joint", "arm_left_6_joint", "arm_left_7_joint",
+                          "gripper_left_joint",
+                          "arm_right_5_joint", "arm_right_6_joint", "arm_right_7_joint",
+                          "gripper_right_joint",
+                          "head_1_joint",
+                          "head_2_joint"]
+    locked_joints = [robotComplete.model.getJointId(el) for el in locked_joints_names]
     robot = robotComplete.buildReducedRobot(locked_joints, qComplete)
     rmodel: pin.Model = robot.model
     q0 = rmodel.referenceConfigurations["half_sitting"]

--- a/include/simple-mpc/robot-handler.hpp
+++ b/include/simple-mpc/robot-handler.hpp
@@ -29,12 +29,7 @@ namespace simple_mpc
   {
   private:
     /**
-     * @brief Robot model with all joints unlocked
-     */
-    Model model_full_;
-
-    /**
-     * @brief Reduced model to be used by ocp
+     * @brief Model to be used by ocp
      */
     Model model_;
 
@@ -82,14 +77,9 @@ namespace simple_mpc
      * @param feet_names Name of the frames corresponding to the feet (e.g. can be
      * used for contact with the ground)
      * @param reference_configuration_name Reference configuration to use
-     * @param locked_joint_names List of joints to lock (values will be fixed at
-     * the reference configuration)
      */
     RobotModelHandler(
-      const Model & model,
-      const std::string & reference_configuration_name,
-      const std::string & base_frame_name,
-      const std::vector<std::string> & locked_joint_names = {});
+      const Model & model, const std::string & reference_configuration_name, const std::string & base_frame_name);
 
     /**
      * @brief
@@ -112,16 +102,6 @@ namespace simple_mpc
      * time to go from x1 to x2.
      */
     Eigen::VectorXd difference(const ConstVectorRef & x1, const ConstVectorRef & x2) const;
-
-    /**
-     * @brief Compute reduced state from measures by concatenating q,v of the
-     * reduced model.
-     *
-     * @param q Configuration vector of the full model
-     * @param v Velocity vector of the full model
-     * @return const Eigen::VectorXd State vector of the reduced model.
-     */
-    Eigen::VectorXd shapeState(const ConstVectorRef & q, const ConstVectorRef & v) const;
 
     // Const getters
     ConstVectorRef getReferenceState() const
@@ -173,11 +153,6 @@ namespace simple_mpc
     const Model & getModel() const
     {
       return model_;
-    }
-
-    const Model & getCompleteModel() const
-    {
-      return model_full_;
     }
   };
 

--- a/include/simple-mpc/robot-handler.hpp
+++ b/include/simple-mpc/robot-handler.hpp
@@ -39,11 +39,6 @@ namespace simple_mpc
     double mass_;
 
     /**
-     * @brief Joint id to be controlled in full model
-     */
-    std::vector<unsigned long> controlled_joints_ids_;
-
-    /**
      * @brief Reference configuration and velocity (most probably null velocity)
      * to use
      */
@@ -127,8 +122,6 @@ namespace simple_mpc
     {
       return feet_names_;
     }
-
-    std::vector<std::string> getControlledJointNames() const;
 
     FrameIndex getBaseFrameId() const
     {

--- a/src/robot-handler.cpp
+++ b/src/robot-handler.cpp
@@ -1,6 +1,5 @@
 #include "simple-mpc/robot-handler.hpp"
 
-#include <iostream>
 #include <pinocchio/algorithm/centroidal.hpp>
 #include <pinocchio/algorithm/compute-all-terms.hpp>
 #include <pinocchio/algorithm/crba.hpp>
@@ -14,10 +13,6 @@ namespace simple_mpc
     const Model & model, const std::string & reference_configuration_name, const std::string & base_frame_name)
   : model_(model)
   {
-    // Controlled joints index
-    for (auto joint_name : model_.names)
-      controlled_joints_ids_.push_back(model.getJointId(joint_name));
-
     // Root frame id
     base_id_ = model_.getFrameId(base_frame_name);
 
@@ -63,16 +58,6 @@ namespace simple_mpc
     dx.tail(nv) = x2.tail(nv) - x1.tail(nv);
 
     return dx;
-  }
-
-  std::vector<std::string> RobotModelHandler::getControlledJointNames() const
-  {
-    std::vector<std::string> joint_names;
-    for (JointIndex id : controlled_joints_ids_)
-    {
-      joint_names.push_back(model_.names.at(id));
-    }
-    return joint_names;
   }
 
   RobotDataHandler::RobotDataHandler(const RobotModelHandler & model_handler)


### PR DESCRIPTION
The model provided to robot-handler constructor should not be reduced by the robot-handler, this is something the user ought to do by himself. 

This PR also corrects the python example for kinodynamics by copying the derivative state at runtime (derivative state is now const and unmodifiable).